### PR TITLE
hal cleanup and doc (if you want it)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ if [[ -d ~/hal ]]; then
   export PATH="${HOME}/hal:\${PATH}"
 fi
 </pre>
+
+# Usage in rails projects
+
+... rudimentary step-by-step for now...
+
+1. git clone kpolitowicz/kamil
+1. clone your rails project
+1. copy .chang/ and .changingnore from there to your rails project
+1. cp config/database.yml.hal config/database.yml
+1. cp config/sunspot.yml.hal config/sunspot.yml
+1. hal build
+1. hal start

--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # Installation
 
+## MacOS
+
 Run:
 
 1. install-hal-dev-proxy
 1. install-hal-shell-completion
 
+## Linux
+
+1. Install puma-dev manually
+1. Run install-hal-dev-proxy
+1. Manually modify PATH to include hal tools
+
+<pre>
+if [[ -d ~/hal ]]; then
+  export PATH="${HOME}/hal:\${PATH}"
+fi
+</pre>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Installation
+
+Run:
+
+1. install-hal-dev-proxy
+1. install-hal-shell-completion
+

--- a/install-hal-dev-proxy
+++ b/install-hal-dev-proxy
@@ -10,7 +10,7 @@ if ! which puma-dev; then
   brew install puma/puma/puma-dev
   security add-trusted-cert -k login.keychain-db ~/Library/Application\ Support/io.puma.dev/cert.pem
   sudo puma-dev -setup
+  puma-dev -install
 fi
 
-puma-dev -install
 

--- a/install-hal-dev-proxy
+++ b/install-hal-dev-proxy
@@ -12,5 +12,5 @@ if ! which puma-dev; then
   sudo puma-dev -setup
 fi
 
-puma-dev -install -install-port 8888
+puma-dev -install
 

--- a/install-hal-dev-proxy
+++ b/install-hal-dev-proxy
@@ -1,0 +1,15 @@
+#!/bin/bash -eu
+
+docker pull majkel/chang-rev-proxy
+set +e
+docker rm -f chang-rev-proxy 2>/dev/null
+set -e
+rm -rf ~/.puma-dev
+if ! which puma-dev; then
+  brew install puma/puma/puma-dev
+  security add-trusted-cert -k login.keychain-db ~/Library/Application\ Support/io.puma.dev/cert.pem
+  sudo puma-dev -setup
+fi
+
+puma-dev -install -install-port 8888
+

--- a/install-hal-dev-proxy
+++ b/install-hal-dev-proxy
@@ -4,7 +4,8 @@ docker pull majkel/chang-rev-proxy
 set +e
 docker rm -f chang-rev-proxy 2>/dev/null
 set -e
-rm -rf ~/.puma-dev
+
+# rm -rf ~/.puma-dev
 if ! which puma-dev; then
   brew install puma/puma/puma-dev
   security add-trusted-cert -k login.keychain-db ~/Library/Application\ Support/io.puma.dev/cert.pem

--- a/install-hal-shell-completion
+++ b/install-hal-shell-completion
@@ -4,20 +4,25 @@ brew tap majkelcc/homebrew-chang-tap
 brew install chang-bash-completion
 brew install chang-zsh-completion
 
-if test -f ~/.bashrc && ! grep -q "hal throwaway" ~/.bashrc; then
-  cat <<EOF >> ~/.bashrc
+if test -f ~/.bashrc; then
+ if ! grep -q "hal throwaway" ~/.bashrc; then
+    cat <<EOF >> ~/.bashrc
 # hal throwaway
 if [[ -d ~/hal ]]; then
   complete -F __chang hal
   export PATH="${HOME}/hal:\${PATH}"
 fi
 EOF
+  else
+    echo "~/.bashrc completion already installed, skipping"
+  fi
 else
   echo "~/.bashrc not found, skipping"
 fi
 
-if test -f ~/.zshrc && ! grep -q "hal throwaway" ~/.zshrc; then
-  cat <<EOF >> ~/.zshrc
+if test -f ~/.zshrc; then
+  if ! grep -q "hal throwaway" ~/.zshrc; then
+    cat <<EOF >> ~/.zshrc
 # hal throwaway
 if [[ -d ~/hal ]]; then
   if [[ -f /usr/local/share/zsh/site-functions/chang ]]; then
@@ -27,6 +32,9 @@ if [[ -d ~/hal ]]; then
   export PATH="${HOME}/hal:\${PATH}"
 fi
 EOF
+  else
+    echo "~/.zshrc completion already installed, skipping"
+  fi
 else
   echo "~/.zshrc not found, skipping"
 fi

--- a/install-hal-shell-completion
+++ b/install-hal-shell-completion
@@ -4,19 +4,6 @@ brew tap majkelcc/homebrew-chang-tap
 brew install chang-bash-completion
 brew install chang-zsh-completion
 
-docker pull majkel/chang-rev-proxy
-set +e
-docker rm -f chang-rev-proxy 2>/dev/null
-set -e
-rm -rf ~/.puma-dev
-if ! which puma-dev; then
-  brew install puma/puma/puma-dev
-  security add-trusted-cert -k login.keychain-db ~/Library/Application\ Support/io.puma.dev/cert.pem
-  sudo puma-dev -setup
-fi
-
-puma-dev -install -install-port 8888
-
 if test -f ~/.bashrc && ! grep -q "hal throwaway" ~/.bashrc; then
   cat <<EOF >> ~/.bashrc
 # hal throwaway

--- a/install-hal-shell-completion
+++ b/install-hal-shell-completion
@@ -31,5 +31,3 @@ else
   echo "~/.zshrc not found, skipping"
 fi
 
-
-echo "DONE"


### PR DESCRIPTION
I was retracing the steps from yesterday and found it better to use separate scripts for proxy setup and for hal commands/shell completion - mostly because linux guys wont have brew so they will install pum-dev manually.

I also added rudimentary README.md, though I'll need your help on documenting all this tool can do (I barely scratched over hal build and hal start)

BTW: hal zsh completion still does not work for me (I fixed compaudit), no idea why, but I didn't look into it too seriously...